### PR TITLE
Versão do Apache Lucene

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,12 +41,12 @@
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-analyzers-common</artifactId>
-            <version>5.3.0</version>
+            <version>7.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-queryparser</artifactId>
-            <version>5.3.0</version>
+            <version>7.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>


### PR DESCRIPTION
O commit e2c27e66b66dc89ae28fdd771affaa4cd5247ad1 mudou a versão do Apache Lucene, mas apenas da dependência "core", e o programa não funciona se os demais componentes não tiverem a mesma versão. 